### PR TITLE
Switch snprintf without params → strncpy

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -589,7 +589,7 @@ int loadLanguage(char* lang)
 	snprintf(fontName, 63, "lang/%s.ttf", lang);
 	if ( access(fontName, F_OK) == -1 )
 	{
-		snprintf(fontName, 63, "lang/en.ttf");
+		strncpy(fontName, "lang/en.ttf", 63);
 	}
 	if ( access(fontName, F_OK) == -1 )
 	{

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -426,11 +426,11 @@ char* Item::description()
 		{
 			if ( itemCategory(this) == WEAPON || itemCategory(this) == ARMOR || itemCategory(this) == MAGICSTAFF || itemCategory(this) == TOOL )
 			{
-				snprintf(tempstr, 1024, language[1034 + status]);
+				strncpy(tempstr, language[1034 + status], 1024);
 			}
 			else if ( itemCategory(this) == AMULET || itemCategory(this) == RING || itemCategory(this) == GEM )
 			{
-				snprintf(tempstr, 1024, language[1039 + status]);
+				strncpy(tempstr, language[1039 + status], 1024);
 			}
 			else if ( itemCategory(this) == POTION )
 			{
@@ -438,11 +438,11 @@ char* Item::description()
 			}
 			else if ( itemCategory(this) == SCROLL || itemCategory(this) == SPELLBOOK || itemCategory(this) == BOOK )
 			{
-				snprintf(tempstr, 1024, language[1049 + status]);
+				strncpy(tempstr, language[1049 + status], 1024);
 			}
 			else if ( itemCategory(this) == FOOD )
 			{
-				snprintf(tempstr, 1024, language[1054 + status]);
+				strncpy(tempstr, language[1054 + status], 1024);
 			}
 			for ( c = 0; c < 1024; c++ )
 				if ( tempstr[c] == 0 )


### PR DESCRIPTION
This fixes compilation on more restrictive settings for gcc, which don't
like this insecure practice. Could also pass -Wno-error=format-insecure
or something like that, but actually solving the issue is always nicer!