### PR TITLE
Enhancement #162 - Add Editor Tool Pencil

### DIFF
--- a/VS.2015/Barony/Barony.vcxproj.filters
+++ b/VS.2015/Barony/Barony.vcxproj.filters
@@ -249,65 +249,8 @@
     <ClCompile Include="..\..\src\player.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\monster_automaton.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_cockatrice.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_crystalgolem.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_goatman.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_incubus.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_insectoid.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_lichfire.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_lichice.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_scarab.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_shadow.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_vampire.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\magic\act_HandMagic.cpp">
       <Filter>Source Files\magic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_kobold.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\actpowercrystal.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\actsummontrap.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\cursors.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\entity_shared.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\item_tool.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_shared.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\stat_shared.cpp">
-      <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\interface\bookgui.cpp">
       <Filter>Source Files\interface</Filter>
@@ -318,13 +261,7 @@
     <ClCompile Include="..\..\src\interface\consolecommand.cpp">
       <Filter>Source Files\interface</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\interface\drawminimap.cpp">
-      <Filter>Source Files\interface</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\interface\drawstatus.cpp">
-      <Filter>Source Files\interface</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\interface\identify_and_appraise.cpp">
       <Filter>Source Files\interface</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\interface\interface.cpp">
@@ -334,9 +271,6 @@
       <Filter>Source Files\interface</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\interface\playerinventory.cpp">
-      <Filter>Source Files\interface</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\interface\removecurse.cpp">
       <Filter>Source Files\interface</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\interface\screenshot.cpp">
@@ -368,6 +302,69 @@
     </ClCompile>
     <ClCompile Include="..\..\src\magic\spell.cpp">
       <Filter>Source Files\magic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\interface\identify_and_appraise.cpp">
+      <Filter>Source Files\interface</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\interface\removecurse.cpp">
+      <Filter>Source Files\interface</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\interface\drawminimap.cpp">
+      <Filter>Source Files\interface</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\actpowercrystal.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\entity_shared.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\item_tool.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_automaton.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_cockatrice.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_crystalgolem.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_goatman.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_incubus.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_insectoid.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_kobold.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_lichfire.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_lichice.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_scarab.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_shadow.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_shared.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_vampire.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\stat_shared.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\actsummontrap.cpp">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -443,26 +440,14 @@
     <ClInclude Include="..\..\src\player.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\collision.hpp">
-      <Filter>Source Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\colors.hpp">
-      <Filter>Source Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\cppfuncs.hpp">
-      <Filter>Source Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\hash.hpp">
-      <Filter>Source Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\paths.hpp">
-      <Filter>Source Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\src\interface\interface.hpp">
       <Filter>Header Files\interface</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\magic\magic.hpp">
       <Filter>Header Files\magic</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\collision.hpp">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/VS.2015/Barony/Barony.vcxproj.filters
+++ b/VS.2015/Barony/Barony.vcxproj.filters
@@ -315,10 +315,10 @@
     <ClCompile Include="..\..\src\actpowercrystal.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\entity_shared.cpp">
+    <ClCompile Include="..\..\src\actsummontrap.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\item_tool.cpp">
+    <ClCompile Include="..\..\src\entity_shared.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\monster_automaton.cpp">
@@ -337,9 +337,6 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\monster_insectoid.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_kobold.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\monster_lichfire.cpp">
@@ -363,7 +360,10 @@
     <ClCompile Include="..\..\src\stat_shared.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\actsummontrap.cpp">
+    <ClCompile Include="..\..\src\monster_kobold.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\item_tool.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
@@ -445,9 +445,6 @@
     </ClInclude>
     <ClInclude Include="..\..\src\magic\magic.hpp">
       <Filter>Header Files\magic</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\collision.hpp">
-      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/VS.2015/Barony/Barony.vcxproj.filters
+++ b/VS.2015/Barony/Barony.vcxproj.filters
@@ -446,6 +446,18 @@
     <ClInclude Include="..\..\src\magic\magic.hpp">
       <Filter>Header Files\magic</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\collision.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cppfuncs.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\hash.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\paths.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="..\..\src\game.ico">

--- a/VS.2015/editor/editor.vcxproj.filters
+++ b/VS.2015/editor/editor.vcxproj.filters
@@ -80,16 +80,10 @@
     <ClCompile Include="..\..\src\entity_editor.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\entity_shared.cpp">
+    <ClCompile Include="..\..\src\items_editor.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\stat_editor.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\stat_shared.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\items_editor.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/VS.2015/editor/editor.vcxproj.filters
+++ b/VS.2015/editor/editor.vcxproj.filters
@@ -86,6 +86,12 @@
     <ClCompile Include="..\..\src\stat_editor.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\entity_shared.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\stat_shared.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\src\wineditoricon.rc">

--- a/src/buttons.cpp
+++ b/src/buttons.cpp
@@ -20,6 +20,7 @@ button_t* butX;
 button_t* but_;
 button_t* butTilePalette;
 button_t* butSprite;
+button_t* butPencil;
 button_t* butPoint;
 button_t* butBrush;
 button_t* butSelect;
@@ -144,27 +145,33 @@ void buttonSprite(button_t* my)
 	spritepalette = 1;
 }
 
-void buttonPoint(button_t* my)
+void buttonPencil(button_t* my)
 {
 	selectedTool = 0;
 	selectedarea = false;
 }
 
-void buttonBrush(button_t* my)
+void buttonPoint(button_t* my)
 {
 	selectedTool = 1;
 	selectedarea = false;
 }
 
-void buttonSelect(button_t* my)
+void buttonBrush(button_t* my)
 {
 	selectedTool = 2;
 	selectedarea = false;
 }
 
-void buttonFill(button_t* my)
+void buttonSelect(button_t* my)
 {
 	selectedTool = 3;
+	selectedarea = false;
+}
+
+void buttonFill(button_t* my)
+{
+	selectedTool = 4;
 	selectedarea = false;
 }
 
@@ -658,7 +665,7 @@ void buttonDelete(button_t* my)
 void buttonSelectAll(button_t* my)
 {
 	menuVisible = 0;
-	selectedTool = 2;
+	selectedTool = 3;
 	selectedarea = true;
 	selectingspace = false;
 	selectedarea_x1 = 0;

--- a/src/cursors.cpp
+++ b/src/cursors.cpp
@@ -55,6 +55,50 @@ char* cursor_pencil[] =
 	"0,0"
 };
 
+char* cursor_point[] =
+{
+	// width height num_colors chars_per_pixel
+	"    32    32        3            1",
+	// colors
+	"X c #000000",
+	". c #ffffff",
+	"  c None",
+	// pixels
+	"     XX                         ",
+	"    X..X                        ",
+	"    X..X                        ",
+	"    X..X                        ",
+	"    X..X                        ",
+	"    X..XXX                      ",
+	"    X..X..XXX                   ",
+	"    X..X..X..XX                 ",
+	"    X..X..X..X.X                ",
+	"XXX X..X..X..X..X               ",
+	"X..XX........X..X               ",
+	"X...X...........X               ",
+	"X...X...........X               ",
+	" X..X...........X               ",
+	"  X.X...........X               ",
+	"  X.............X               ",
+	"   X............X               ",
+	"   X...........X                ",
+	"    X..........X                ",
+	"    X..........X                ",
+	"     X........X                 ",
+	"     X........X                 ",
+	"     XXXXXXXXXX                 ",
+	"                                ",
+	"                                ",
+	"                                ",
+	"                                ",
+	"                                ",
+	"                                ",
+	"                                ",
+	"                                ",
+	"                                ",
+	"5,0"
+};
+
 char* cursor_brush[] =
 {
 	// width height num_colors chars_per_pixel

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1223,6 +1223,7 @@ int main(int argc, char** argv)
 	// load cursors
 	cursorArrow = SDL_GetCursor();
 	cursorPencil = newCursor(cursor_pencil);
+	cursorPoint = newCursor(cursor_point);
 	cursorBrush = newCursor(cursor_brush);
 	cursorSelect = cursorArrow;
 	cursorFill = newCursor(cursor_fill);
@@ -1363,34 +1364,47 @@ int main(int argc, char** argv)
 	button->sizey = 16;
 	button->action = &buttonSprite;
 
-	button = butPoint = newButton();
-	strcpy(button->label, "Point");
+	// Pencil Tool Button
+	button = butPencil = newButton();
+	strcpy(button->label, "Pencil");
 	button->x = xres - 96;
 	button->y = 204;
 	button->sizex = 64;
 	button->sizey = 16;
-	button->action = &buttonPoint;
+	button->action = &buttonPencil;
 
-	button = butBrush = newButton();
-	strcpy(button->label, "Brush");
+	// Point Tool Button
+	button = butPoint = newButton();
+	strcpy(button->label, "Point");
 	button->x = xres - 96;
 	button->y = 220;
 	button->sizex = 64;
 	button->sizey = 16;
-	button->action = &buttonBrush;
+	button->action = &buttonPoint;
 
-	button = butSelect = newButton();
-	strcpy(button->label, "Select");
+	// Brush Tool Button
+	button = butBrush = newButton();
+	strcpy(button->label, "Brush");
 	button->x = xres - 96;
 	button->y = 236;
 	button->sizex = 64;
 	button->sizey = 16;
+	button->action = &buttonBrush;
+
+	// Select Tool Button
+	button = butSelect = newButton();
+	strcpy(button->label, "Select");
+	button->x = xres - 96;
+	button->y = 252;
+	button->sizex = 64;
+	button->sizey = 16;
 	button->action = &buttonSelect;
 
+	// Fill Tool Button
 	button = butFill = newButton();
 	strcpy(button->label, "Fill");
 	button->x = xres - 96;
-	button->y = 252;
+	button->y = 268;
 	button->sizex = 64;
 	button->sizey = 16;
 	button->action = &buttonFill;
@@ -1705,16 +1719,19 @@ int main(int argc, char** argv)
 				// set the cursor
 				switch ( selectedTool )
 				{
-					case 0:
+					case 0: // Pencil
 						SDL_SetCursor(cursorPencil);
 						break;
-					case 1:
+					case 1: // Point
+						SDL_SetCursor(cursorPoint);
+						break;
+					case 2: // Brush
 						SDL_SetCursor(cursorBrush);
 						break;
-					case 2:
+					case 3: // Select
 						SDL_SetCursor(cursorSelect);
 						break;
-					case 3:
+					case 4: // Fill
 						SDL_SetCursor(cursorFill);
 						break;
 					default:
@@ -1740,9 +1757,6 @@ int main(int argc, char** argv)
 									{
 										duplicatedSprite = false;
 										makeUndo();
-									}
-									else
-									{
 									}
 								}
 								mousestatus[SDL_BUTTON_LEFT] = 0;
@@ -1776,7 +1790,7 @@ int main(int argc, char** argv)
 						{
 							if ( (omousex + camx) >> TEXTUREPOWER == entity->x / 16 && (omousey + camy) >> TEXTUREPOWER == entity->y / 16 )
 							{
-								if ( mousestatus[SDL_BUTTON_LEFT] && selectedTool != 1 )
+								if ( mousestatus[SDL_BUTTON_LEFT] && selectedTool == 1 )
 								{
 									// select sprite
 									selectedEntity = entity;
@@ -1789,7 +1803,7 @@ int main(int argc, char** argv)
 										makeUndo();
 									}
 								}
-								else if ( mousestatus[SDL_BUTTON_RIGHT] )
+								else if ( mousestatus[SDL_BUTTON_RIGHT] && selectedTool == 1 )
 								{
 									// duplicate sprite
 									duplicatedSprite = true;
@@ -1821,24 +1835,34 @@ int main(int argc, char** argv)
 						}
 						if ( !pasting )   // not pasting, normal editing mode
 						{
-							if ( selectedTool == 0 )   // point draw
+							if ( selectedTool == 0 )			// Process Pencil Tool functionality
 							{
 								if ( drawx >= 0 && drawx < map.width && drawy >= 0 && drawy < map.height )
 								{
 									map.tiles[drawlayer + drawy * MAPLAYERS + drawx * MAPLAYERS * map.height] = selectedTile;
 								}
 							}
-							else if ( selectedTool == 1 )     // brush tool
+							else if ( selectedTool == 1 )		// Process Point Tool functionality
 							{
-								for (x = drawx - 1; x <= drawx + 1; x++)
-									for (y = drawy - 1; y <= drawy + 1; y++)
+								// All functionality of the Point Tool is encapsulated above in the "move entities" section
+							}
+							else if ( selectedTool == 2 )		// Process Brush Tool functionality
+							{
+								for ( x = drawx - 1; x <= drawx + 1; x++ )
+								{
+									for ( y = drawy - 1; y <= drawy + 1; y++ )
+									{
 										if ( (x != drawx - 1 || y != drawy - 1) && (x != drawx + 1 || y != drawy - 1) && (x != drawx - 1 || y != drawy + 1) && (x != drawx + 1 || y != drawy + 1) )
+										{
 											if ( x >= 0 && x < map.width && y >= 0 && y < map.height )
 											{
 												map.tiles[drawlayer + y * MAPLAYERS + x * MAPLAYERS * map.height] = selectedTile;
 											}
+										}
+									}
+								}
 							}
-							else if ( selectedTool == 2 )     // select tool
+							else if ( selectedTool == 3 )		// Process Select Tool functionality
 							{
 								if ( selectingspace == false )
 								{
@@ -1880,7 +1904,7 @@ int main(int argc, char** argv)
 									}
 								}
 							}
-							else if ( selectedTool == 3 )     // fill tool
+							else if ( selectedTool == 4 )		// Process Fill Tool functionality
 							{
 								if ( drawx >= 0 && drawx < map.width && drawy >= 0 && drawy < map.height )
 								{
@@ -1917,7 +1941,7 @@ int main(int argc, char** argv)
 				}
 				if ( mousestatus[SDL_BUTTON_RIGHT] && selectedEntity == NULL )
 				{
-					if ( selectedTool != 2 )
+					if ( selectedTool != 3 )
 					{
 						if ( drawx >= 0 && drawx < map.width && drawy >= 0 && drawy < map.height )
 						{
@@ -2066,16 +2090,19 @@ int main(int argc, char** argv)
 				switch ( selectedTool )
 				{
 					case 0:
-						printText(font8x8_bmp, xres - 84, 276, "POINT");
+						printText(font8x8_bmp, xres - 84, 292, "PENCIL");
 						break;
 					case 1:
-						printText(font8x8_bmp, xres - 84, 276, "BRUSH");
+						printText(font8x8_bmp, xres - 84, 292, "POINT");
 						break;
 					case 2:
-						printText(font8x8_bmp, xres - 88, 276, "SELECT");
+						printText(font8x8_bmp, xres - 88, 292, "BRUSH");
 						break;
 					case 3:
-						printText(font8x8_bmp, xres - 80, 276, "FILL");
+						printText(font8x8_bmp, xres - 80, 292, "SELECT");
+						break;
+					case 4:
+						printText(font8x8_bmp, xres - 80, 292, "FILL");
 						break;
 				}
 
@@ -4016,28 +4043,34 @@ int main(int argc, char** argv)
 					keystatus[SDL_SCANCODE_F1] = 0;
 					buttonAbout(NULL);
 				}
-				if ( keystatus[SDL_SCANCODE_1] )
+				if ( keystatus[SDL_SCANCODE_1] ) // "1" - Switch to Pencil Tool
 				{
 					keystatus[SDL_SCANCODE_1] = 0;
 					selectedTool = 0;
 					selectedarea = false;
 				}
-				if ( keystatus[SDL_SCANCODE_2] )
+				if ( keystatus[SDL_SCANCODE_2] ) // "2" - Switch to Point Tool
 				{
 					keystatus[SDL_SCANCODE_2] = 0;
 					selectedTool = 1;
 					selectedarea = false;
 				}
-				if ( keystatus[SDL_SCANCODE_3] )
+				if ( keystatus[SDL_SCANCODE_3] ) // "3" - Switch to Brush Tool
 				{
 					keystatus[SDL_SCANCODE_3] = 0;
 					selectedTool = 2;
 					selectedarea = false;
 				}
-				if ( keystatus[SDL_SCANCODE_4] )
+				if ( keystatus[SDL_SCANCODE_4] ) // "4" - Switch to Select Tool
 				{
 					keystatus[SDL_SCANCODE_4] = 0;
 					selectedTool = 3;
+					selectedarea = false;
+				}
+				if ( keystatus[SDL_SCANCODE_5] ) // "5" - Switch to Fill Tool
+				{
+					keystatus[SDL_SCANCODE_5] = 0;
+					selectedTool = 4;
 					selectedarea = false;
 				}
 				if ( keystatus[SDL_SCANCODE_F2] )
@@ -4406,6 +4439,7 @@ int main(int argc, char** argv)
 	// deinit
 	SDL_SetCursor(cursorArrow);
 	SDL_FreeCursor(cursorPencil);
+	SDL_FreeCursor(cursorPoint);
 	SDL_FreeCursor(cursorBrush);
 	SDL_FreeCursor(cursorFill);
 	if ( palette != NULL )

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -50,7 +50,7 @@ extern char message[48];
 extern int messagetime;
 extern char widthtext[4], heighttext[4], nametext[32], authortext[32], skyboxtext[4];
 extern int editproperty;
-extern SDL_Cursor* cursorArrow, *cursorPencil, *cursorBrush, *cursorSelect, *cursorFill;
+extern SDL_Cursor* cursorArrow, *cursorPencil, *cursorPoint, *cursorBrush, *cursorSelect, *cursorFill;
 extern int* palette;
 
 // button definitions
@@ -58,6 +58,7 @@ extern button_t* butX;
 extern button_t* but_;
 extern button_t* butTilePalette;
 extern button_t* butSprite;
+extern button_t* butPencil;
 extern button_t* butPoint;
 extern button_t* butBrush;
 extern button_t* butSelect;
@@ -143,6 +144,7 @@ void buttonExitConfirm(button_t* my);
 void buttonIconify(button_t* my);
 void buttonTilePalette(button_t* my);
 void buttonSprite(button_t* my);
+void buttonPencil(button_t* my);
 void buttonPoint(button_t* my);
 void buttonBrush(button_t* my);
 void buttonSelect(button_t* my);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,7 +155,7 @@ int selectedTile = 0;
 int tilepalette = 0;
 int spritepalette = 0;
 int mclick = 0;
-int selectedTool = 0; // 0: point draw 1: brush 2: select 3: fill
+int selectedTool = 0; // 0: Pencil 1: Point 2: Brush 3: Select 4: Fill
 int allowediting = 0; // only turned on when the mouse is over paintable screen region
 int openwindow = 0, savewindow = 0, newwindow = 0;
 int slidery = 0, slidersize = 16;
@@ -171,7 +171,7 @@ char widthtext[4], heighttext[4], nametext[32], authortext[32], skyboxtext[32];
 char spriteProperties[32][128];
 char tmpSpriteProperties[32][128];
 int editproperty = 0;
-SDL_Cursor* cursorArrow, *cursorPencil, *cursorBrush, *cursorSelect, *cursorFill;
+SDL_Cursor* cursorArrow, *cursorPencil, *cursorPoint, *cursorBrush, *cursorSelect, *cursorFill;
 int* palette;
 
 // video definitions

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -651,6 +651,7 @@ void assignActions(map_t* map);
 
 // cursor bitmap definitions
 extern char* cursor_pencil[];
+extern char* cursor_point[];
 extern char* cursor_brush[];
 extern char* cursor_fill[];
 


### PR DESCRIPTION
This is an enhancement for the Editor, #162.
The Pencil Tool was created to only draw Tiles. The Point Tool was given a new unique Cursor, and only selects and moves Entities. The Pencil Tool cannot interact with Entities, only Tiles. The Point Tool cannot interact with Tiles, only Entities.

Additionally, the Pencil Tool is now the default, with everything being properly shifted, including the hotkeys (1-5 now).